### PR TITLE
Enabling network permissions for the SDK server

### DIFF
--- a/org.openrgb.OpenRGB.yaml
+++ b/org.openrgb.OpenRGB.yaml
@@ -6,6 +6,7 @@ command: openrgb
 finish-args:
   - --device=all
   - --share=ipc
+  - --share=network
   - --socket=wayland
   - --socket=fallback-x11
   # Tray Icon


### PR DESCRIPTION
SDK server requires access to the network to be able to listen for connections, which this PR enables.

Bug was originally reported on the subreddit: https://www.reddit.com/r/OpenRGB/comments/vg6az5/connection_refused_in_openrgbpython/

