### PR TITLE
Update Runtime

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-    "automerge-flathubbot-prs": true
+    "automerge-flathubbot-prs": false
 }

--- a/org.openrgb.OpenRGB.yaml
+++ b/org.openrgb.OpenRGB.yaml
@@ -1,7 +1,7 @@
 id: org.openrgb.OpenRGB
 sdk: org.kde.Sdk
 runtime: org.kde.Platform
-runtime-version: 5.15-23.08
+runtime-version: 5.15-24.08
 command: openrgb
 finish-args:
   - --device=all


### PR DESCRIPTION
This just bumps the runtime for the KDE Platform to 24.08 to avoid warnings being thrown, as 23.08 is now officially EOL. Build works fine in my testing.