### PR TITLE
README: Add header and fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# OpenRGB
+
+Open source RGB lighting control that doesn't depend on manufacturer software. [openrgb.org](https://openrgb.org)
+
 ## Udev rules
 
 To ensure you have device permissions please install the latest UDEV rules.
@@ -8,12 +12,12 @@ To ensure you have device permissions please install the latest UDEV rules.
   sudo dnf install openrgb-udev-rules
   ```
 
-* If you need to install the UDEV rules file manually you can also download the [latest compiled udev rules](https://gitlab.com/CalcProgrammer1/OpenRGB/-/jobs/artifacts/master/raw/60-openrgb.rules?job=Linux+64+AppImage&inline=false) from Gitlab.
+* If you need to install the UDEV rules file manually you can also download the [latest compiled udev rules](https://gitlab.com/CalcProgrammer1/OpenRGB/-/jobs/artifacts/master/raw/60-openrgb.rules?job=Linux+amd64+AppImage&inline=false) from GitLab.
 
   - Copy this `60-openrgb.rules` file to `/usr/lib/udev/rules.d/`
   - Then reload rules with `sudo udevadm control --reload-rules && sudo udevadm trigger`
 
-See: https://gitlab.com/CalcProgrammer1/OpenRGB#installing-udev-rules-manually.
+See: https://gitlab.com/CalcProgrammer1/OpenRGB/-/blob/master/Documentation/UdevRules.md
 
 ## OpenRGB Pipeline (Experimental)
 


### PR DESCRIPTION
Adds a header with a short description and fixes broken/outdated Udev links in the README