### PR TITLE
Update released version to 1.0rc3

### DIFF
--- a/org.openrgb.OpenRGB.yaml
+++ b/org.openrgb.OpenRGB.yaml
@@ -61,7 +61,7 @@ modules:
     sources:
       - type: git
         url: https://gitlab.com/CalcProgrammer1/OpenRGB
-        tag: release_candidate_1.0rc2
-        commit: 0fca93e4544f943d4d7ec8073dba4e47c18ef54b
+        tag: release_candidate_1.0rc3
+        commit: 6fbcf62d7694e7b92fd0a5884b40b92984fbd1b0
       - type: patch
         path: patches/metainfo.patch

--- a/patches/metainfo.patch
+++ b/patches/metainfo.patch
@@ -1,13 +1,10 @@
-diff --git a/qt/org.openrgb.OpenRGB.metainfo.xml b/qt/org.openrgb.OpenRGB.metainfo.xml
-index 65dc783e..dad33dc2 100644
 --- a/qt/org.openrgb.OpenRGB.metainfo.xml
 +++ b/qt/org.openrgb.OpenRGB.metainfo.xml
-@@ -48,6 +48,8 @@
+@@ -48,6 +48,7 @@
    </description>
  
    <releases>
-+    <release version="1.0rc2" date="2025-09-14"></release>
-+    <release version="1.0rc1" date="2025-02-22"></release>
++    <release version="1.0rc3" date="2026-06-28"></release>
+     <release version="1.0rc2" date="2025-09-14"></release>
+     <release version="1.0rc1" date="2025-02-22"></release>
      <release version="0.9" date="2023-06-09"></release>
-     <release version="0.8" date="2022-11-27"></release>
-     <release version="0.7" date="2021-12-30"></release>


### PR DESCRIPTION
I just released OpenRGB 1.0rc3, updating Flathub build.