### PR TITLE
Set subdirectories: true in extension org.openrgb.OpenRGB.Plugin

### DIFF
--- a/org.openrgb.OpenRGB.yaml
+++ b/org.openrgb.OpenRGB.yaml
@@ -27,7 +27,7 @@ add-extensions:
     version: '5'
     directory: lib/openrgb/plugins
     add-ld-path: lib
-    subdirectories: false
+    subdirectories: true
     no-autodownload: false
     
 modules:


### PR DESCRIPTION
Forgot to set this to true after reworking plugin loading logic.  Plugins are each mounted to their own directory:

example:

/app/lib/openrgb/plugins/Effects/libOpenRGBEffectsPlugin.so
/app/lib/openrgb/plugins/VisualMap/libOpenRGBVisualMapPlugin.so